### PR TITLE
POC of event overrides

### DIFF
--- a/Classes/Service/Validator.php
+++ b/Classes/Service/Validator.php
@@ -21,9 +21,9 @@ class Validator
 	protected Configuration $configuration;
 	protected LoggerInterface $logger;
 
-	public function __construct(ClientInterface $client, LoggerInterface $logger) {
+	public function __construct(ClientInterface $client, LoggerInterface $logger, Configuration $configuration) {
 		$this->client = $client;
-		$this->configuration = new Configuration();
+		$this->configuration = $configuration;
 		$this->logger = $logger;
 	}
 


### PR DESCRIPTION
adds  possibility to override config variables via custom events using PSR events

property names are:
 * host
 * keyPublic
 * keyREST

```
<?php
// EXT:your_extension/Classes/EventListener/CaptchaConfigurationListener.php
namespace YourVendor\YourExtension\EventListener;

use CaptchaEU\Typo3\ModifyConfigValueEvent;

class CaptchaConfigurationListener
{
    public function __invoke(ModifyConfigValueEvent $event): ModifyConfigValueEvent
    {
        // Example: modify host
        if ($event->getProperty() === 'host') {
            return new ModifyConfigValueEvent('https://your-custom-host.com', 'host');
        }

        return $event;
    }
}
```

```
// EXT:your_extension/Configuration/Services.yaml
services:
  YourVendor\YourExtension\EventListener\CaptchaConfigurationListener:
    tags:
      - name: event.listener
        event: CaptchaEU\Typo3\ModifyConfigValueEvent
```