### PR TITLE
Let dependency injection pass the configuration to the viewhelper.

### DIFF
--- a/Classes/ViewHelpers/ConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/ConfigurationViewHelper.php
@@ -13,9 +13,9 @@ class ConfigurationViewHelper extends AbstractViewHelper
 {
     protected Configuration $configuration;
 
-    public function __construct() 
+    public function __construct(Configuration $configuration)
     {
-        $this->configuration = GeneralUtility::makeInstance(Configuration::class);
+        $this->configuration = $configuration;
     }
 
     public function render()


### PR DESCRIPTION
Hi @hjanuschka,

after #14 and #15 there was still one small thing, that led to the new event not being used. Since the `Configuration` was not autowired into the viewhelper no dependencies were passed to it when creating it via `GeneralUtility`.

The docs about dependency injection and [when to use GeneralUtility](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/DependencyInjection/Index.html#when-to-use-php-generalutility-makeinstance) instead did not cover this specific case with an example, but it makes sense as to why an object gets instanced differently.

Anyways, this small PR should finally get the event to a working state.

Greetings,
Benni