### PR TITLE
Add TYPO3 13 compatibility and modernize codebase

### DIFF
--- a/Classes/Form/FormValidator.php
+++ b/Classes/Form/FormValidator.php
@@ -5,17 +5,21 @@ declare(strict_types=1);
 namespace CaptchaEU\Typo3\Form;
 
 use CaptchaEU\Typo3\Service\Validator;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
 
 class FormValidator extends AbstractValidator
 {
-        protected $acceptsEmptyValues = false;
+	protected $acceptsEmptyValues = false;
+	
+	private Validator $validator;
+	
+	public function __construct(Validator $validator)
+	{
+		$this->validator = $validator;
+	}
 	protected function isValid($solution): void
 	{
-		// get validator instance
-		$captchaEUValidator = GeneralUtility::makeInstance(Validator::class);
-		$isValid = $captchaEUValidator->validate($solution);
+		$isValid = $this->validator->validate($solution);
 
 		// check if solution is valid
 		if (!$isValid) {

--- a/Classes/Service/Validator.php
+++ b/Classes/Service/Validator.php
@@ -13,7 +13,6 @@ use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Log\LogManager;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class Validator
 {
@@ -23,16 +22,21 @@ class Validator
 	protected ClientInterface $client;
 	protected Configuration $configuration;
 	protected LoggerInterface $logger;
+	protected RequestFactory $requestFactory;
 
-	public function __construct(ClientInterface $client, LoggerInterface $logger, Configuration $configuration) {
+	public function __construct(
+		ClientInterface $client,
+		LoggerInterface $logger,
+		Configuration $configuration,
+		RequestFactory $requestFactory
+	) {
 		$this->client = $client;
 		$this->configuration = $configuration;
 		$this->logger = $logger;
+		$this->requestFactory = $requestFactory;
 	}
 
 	public function checkSolution($solution, $key, $endpoint) {
-		
-		$requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
 		
 		try {
 			$payload = [
@@ -43,7 +47,7 @@ class Validator
 				'body' => $solution
 			];
 		
-			$response = $requestFactory->request(
+			$response = $this->requestFactory->request(
 				$endpoint,
 				'POST',
 				$payload,

--- a/Classes/ViewHelpers/ConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/ConfigurationViewHelper.php
@@ -18,6 +18,11 @@ class ConfigurationViewHelper extends AbstractViewHelper
         $this->configuration = $configuration;
     }
 
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+    }
+
     public function render()
     {
         return [

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 		"issues": "https://github.com/captcha-eu/typo3/issues"
 	},
 	"require": {
-      "typo3/cms-core": "^11.5 || ^12.4 || ^13.4"
+		"php": "^8.1 || ^8.2 || ^8.3",
+		"typo3/cms-core": "^11.5 || ^12.4 || ^13.4"
 	},
 	"suggest": {
 		"typo3/cms-form": "*"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,7 +4,7 @@
  * Extension Manager/Repository config for ext "captchaeu_typo3"
  ***************************************************************/
 
-$EM_CONF[$_EXTKEY] = [
+$EM_CONF['captchaeu_typo3'] = [
 	'title' => 'Captcha.eu',
 	'description' => 'Captcha.eu - The intelligent GDPR-compliant Captcha solution without interrupting puzzles or riddles',
 	'category' => 'plugin',
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = [
 	'version' => '1.0.5',
 	'constraints' => [
 		'depends' => [
-			'typo3' => '11.5.0-12.4.99'
+			'typo3' => '11.5.0-13.4.99'
 		],
 		'conflicts' => [],
 		'suggests' => []


### PR DESCRIPTION
## Summary
- Added TYPO3 13 support while maintaining compatibility with TYPO3 11 and 12
- Modernized codebase by removing deprecated APIs and following current best practices
- Improved dependency injection patterns throughout the extension

## Changes
- **composer.json**: Added PHP version requirement (8.1-8.3)
- **ext_emconf.php**: 
  - Replaced deprecated `$_EXTKEY` with hardcoded extension key
  - Updated TYPO3 version constraint to include 13.4
- **FormValidator**: Refactored to use constructor injection instead of `GeneralUtility::makeInstance()`
- **Validator service**: Added RequestFactory via dependency injection
- **ConfigurationViewHelper**: Added `initializeArguments()` method for better ViewHelper practice

## Test plan
- [ ] Test extension installation on TYPO3 11.5
- [ ] Test extension installation on TYPO3 12.4
- [ ] Test extension installation on TYPO3 13.4
- [ ] Verify form validation works correctly
- [ ] Check that captcha functionality remains intact
- [ ] Ensure no deprecation warnings in TYPO3 13

🤖 Generated with [Claude Code](https://claude.ai/code)