### PR TITLE
Allow installation with PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP
@@ -41,11 +41,15 @@ jobs:
             php-version: '8.3'
           - typo3-version: '^13.4'
             php-version: '8.4'
+          - typo3-version: '^13.4'
+            php-version: '8.5'
           # TYPO3 14 (development)
           - typo3-version: '^14.0'
             php-version: '8.3'
           - typo3-version: '^14.0'
             php-version: '8.4'
+          - typo3-version: '^14.0'
+            php-version: '8.5'
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"issues": "https://github.com/captcha-eu/typo3/issues"
 	},
 	"require": {
-		"php": "^8.2 || ^8.3 || ^8.4",
+		"php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
 		"typo3/cms-core": "^12.4 || ^13.4 || ^14.0"
 	},
 	"require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF['captchaeu_typo3'] = [
 	'constraints' => [
 		'depends' => [
 			'typo3' => '12.4.0-14.4.99',
-			'php' => '8.2.0-8.4.99'
+			'php' => '8.2.0-8.5.99'
 		],
 		'conflicts' => [],
 		'suggests' => []


### PR DESCRIPTION
All code is compatible with PHP 8.5, so this patch only adds 8.5 to allowed PHP versions in composer.json, ci config and the `ext_emconf.php` file