### PR TITLE
[BUG] Remove deprecated IconRegistry instantiation

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,18 +2,6 @@
 
 defined('TYPO3') or die();
 
-$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-    \TYPO3\CMS\Core\Imaging\IconRegistry::class
-);
-
-$iconRegistry->registerIcon(
-    'captchaeu-icon',
-    \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-    [
-        'source' => 'EXT:captchaeu_typo3/Resources/Public/Icons/captchaeu-icon.svg'
-    ]
-);
-
 call_user_func(function() {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
         trim('


### PR DESCRIPTION
## Problem

Instantiation of `IconRegistry` in `ext_localconf.php` is deprecated since TYPO3 v13 and throws a RuntimeError in TYPO3 v14.

Upstream changes:
- https://github.com/TYPO3/typo3/commit/2b5a88a3bba6e599bfe556a33d47986c2b99e105
- https://github.com/TYPO3/typo3/commit/f8ab685826aa58ca7070d87b10afa76e87d87ebf

## Solution

Removed deprecated `IconRegistry` instantiation from `ext_localconf.php`.

## Compatibility

Tested with:
- TYPO3 v12
- TYPO3 v13
- TYPO3 v14

No breaking changes expected.